### PR TITLE
Disable unit variance scalling. Filter low expressed genes/transcript…

### DIFF
--- a/scripts/zpca-tpm
+++ b/scripts/zpca-tpm
@@ -37,8 +37,8 @@ def main():
     parser.add_argument(
         "--tpm-filter",
         dest="tpm_filter",
-        default=1,
-        help="Filter genes/transcripts with mean expression less than the provided filter. Default: 1",
+        default=0,
+        help="Filter genes/transcripts with mean expression less than the provided filter. Default: 0",
         required=False,
     )
     

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 
 setup(
     name='zpca',
-    version='0.5',
+    version='0.7',
     description="PCA analysis for genes or transcripts.",
     author="Foivos Gypas",
     author_email='fgypas@gmail.com',

--- a/zpca/zpca.py
+++ b/zpca/zpca.py
@@ -28,7 +28,7 @@ def perform_pca(df, n_components):
 
     df = df.astype(float)
 
-    scaled_data = preprocessing.scale(df.T)
+    scaled_data = preprocessing.scale(df, with_std=False)
 
     pca = PCA(n_components=n_components)
     pca.fit(scaled_data)


### PR DESCRIPTION
- Disable unit variance scaling.
- Filter low expressed genes/transcripts >0 instead of >1.